### PR TITLE
Fixing comptability for jQuery 1.6+

### DIFF
--- a/jquery.easy-confirm-dialog.js
+++ b/jquery.easy-confirm-dialog.js
@@ -29,6 +29,18 @@
   };
   
 	$.fn.easyconfirm = function(options) {
+	  // Punch a duck
+      // http://paulirish.com/2010/duck-punching-with-jquery/
+	  var _attr = $.fn.attr;
+	  $.fn.attr = function (attr, value) {
+		// Let the original attr() do its work.
+		var returned = _attr.apply(this, arguments);
+		// Fix for jQuery 1.6+
+		if (attr == 'title' && returned == undefined)
+			returned = '';
+		return returned;
+	  };
+
 	  var options = jQuery.extend({
 	    eventType: 'click',
 	    icon: 'help'
@@ -108,7 +120,6 @@
 	                       draggable: true,
 	                       closeOnEscape: true,
 	                       width: 'auto',
-	                       height: 120,
 	                       minHeight: 120,
 	                       maxHeight: 200,
 	                       buttons: buttons,


### PR DESCRIPTION
I tried using your library today with jQuery 1.6.1 and got and error because .attr() now return undefined if the attribute is not set, so line 76 (if ($target.attr('title').length > 0)) would break. I wondered how I could fix it and keep backward comptability. I figured duck punching (http://paulirish.com/2010/duck-punching-with-jquery/) was the best solution. Also, the height of 120 was too small to show just a single line, so I removed it. This is my first pull request so tell me if I did anything wrong.
